### PR TITLE
fix V575 from PVS-Studio

### DIFF
--- a/3rdparty/webrtc/Microstack/ILibWrapperWebRTC.c
+++ b/3rdparty/webrtc/Microstack/ILibWrapperWebRTC.c
@@ -881,8 +881,8 @@ char* ILibWrapper_WebRTC_Connection_SetOffer(ILibWrapper_WebRTC_Connection conne
 	ILibRemoteLogging_printf(ILibChainGetLogger(obj->mFactory->mChain), ILibRemoteLogging_Modules_WebRTC_STUN_ICE, ILibRemoteLogging_Flags_VerbosityLevel_1, "[ILibWrapperWebRTC] Return ICE/Response: <br/>%s", sdp);
 
 	ILibWebRTC_SetUserObject(obj->mFactory->mStunModule, un, obj);
-	memcpy(obj->localUsername, un, strlen(un));
-	memcpy(obj->localPassword, up, strlen(up));
+	strcpy_s(obj->localUsername, sizeof(obj->localUsername), un);
+	strcpy_s(obj->localPassword, sizeof(obj->localPassword), up);
 
 	free(un);
 	free(up);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: [V575](https://www.viva64.com/en/w/v575/) The 'memcpy' function doesn't copy the whole string. Use 'strcpy / strcpy_s' function to preserve terminal null.

https://github.com/HumbleNet/HumbleNet/blob/master/3rdparty/webrtc/Microstack/ILibWrapperWebRTC.c#L884
https://github.com/HumbleNet/HumbleNet/blob/master/3rdparty/webrtc/Microstack/ILibWrapperWebRTC.c#L885