### PR TITLE
V575 free fix

### DIFF
--- a/3rdparty/webrtc/Microstack/ILibParsers.c
+++ b/3rdparty/webrtc/Microstack/ILibParsers.c
@@ -7044,7 +7044,6 @@ int ILibTime_ParseEx(char *timeString, time_t *val)
 		}
 		else
 		{
-			free(startTime);
 			//
 			// Invalid Date portion
 			//

--- a/3rdparty/webrtc/Microstack/ILibParsers.c
+++ b/3rdparty/webrtc/Microstack/ILibParsers.c
@@ -7062,6 +7062,7 @@ int ILibTime_ParseEx(char *timeString, time_t *val)
 	//
 	if (errCode!=0)
 	{
+		if (startTime != NULL) free(startTime);
 		return(1);
 	}
 

--- a/3rdparty/webrtc/Microstack/ILibWrapperWebRTC.c
+++ b/3rdparty/webrtc/Microstack/ILibWrapperWebRTC.c
@@ -881,8 +881,8 @@ char* ILibWrapper_WebRTC_Connection_SetOffer(ILibWrapper_WebRTC_Connection conne
 	ILibRemoteLogging_printf(ILibChainGetLogger(obj->mFactory->mChain), ILibRemoteLogging_Modules_WebRTC_STUN_ICE, ILibRemoteLogging_Flags_VerbosityLevel_1, "[ILibWrapperWebRTC] Return ICE/Response: <br/>%s", sdp);
 
 	ILibWebRTC_SetUserObject(obj->mFactory->mStunModule, un, obj);
-	memcpy(obj->localUsername, un, strlen(un));
-	memcpy(obj->localPassword, up, strlen(up));
+	strcpy_s(obj->localUsername, sizeof(obj->localUsername), un);
+	strcpy_s(obj->localPassword, sizeof(obj->localPassword), up);
 
 	free(un);
 	free(up);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: [V575](https://www.viva64.com/en/w/v575/) The null pointer is passed into 'free' function. Inspect the first argument. 

(https://github.com/HumbleNet/HumbleNet/blob/master/3rdparty/webrtc/Microstack/ILibParsers.c#L7047)